### PR TITLE
Access route properties using getters

### DIFF
--- a/vendor-addon/document-title/document-title.js
+++ b/vendor-addon/document-title/document-title.js
@@ -1,3 +1,5 @@
+var get = Ember.get;
+
 // Extend Ember.Route to add support for sensible
 // document.title integration.
 Ember.Route.reopen({
@@ -17,9 +19,9 @@ Ember.Route.reopen({
   // Provided by Ember
   _actions: {
     collectTitleTokens: function(tokens) {
-      var titleToken = Ember.get(this, 'titleToken');
+      var titleToken = get(this, 'titleToken');
       if (typeof titleToken === 'function') {
-        titleToken = titleToken(Ember.get(this, 'currentModel'));
+        titleToken = titleToken(get(this, 'currentModel'));
       }
 
       if (Ember.isArray(titleToken)) {
@@ -30,7 +32,7 @@ Ember.Route.reopen({
 
       // If `title` exists, it signals the end of the
       // token-collection, and the title is decided right here.
-      var title = Ember.get(this, 'title');
+      var title = get(this, 'title');
       if (title) {
         var finalTitle;
         if (typeof title === 'function') {

--- a/vendor-addon/document-title/document-title.js
+++ b/vendor-addon/document-title/document-title.js
@@ -17,9 +17,9 @@ Ember.Route.reopen({
   // Provided by Ember
   _actions: {
     collectTitleTokens: function(tokens) {
-      var titleToken = this.get('titleToken');
+      var titleToken = Ember.get(this, 'titleToken');
       if (typeof titleToken === 'function') {
-        titleToken = titleToken(this.currentModel);
+        titleToken = titleToken(Ember.get(this, 'currentModel'));
       }
 
       if (Ember.isArray(titleToken)) {
@@ -30,7 +30,7 @@ Ember.Route.reopen({
 
       // If `title` exists, it signals the end of the
       // token-collection, and the title is decided right here.
-      var title = this.get('title');
+      var title = Ember.get(this, 'title');
       if (title) {
         var finalTitle;
         if (typeof title === 'function') {

--- a/vendor-addon/document-title/document-title.js
+++ b/vendor-addon/document-title/document-title.js
@@ -17,9 +17,9 @@ Ember.Route.reopen({
   // Provided by Ember
   _actions: {
     collectTitleTokens: function(tokens) {
-      var titleToken = this.titleToken;
-      if (typeof this.titleToken === 'function') {
-        titleToken = this.titleToken(this.currentModel);
+      var titleToken = this.get('titleToken');
+      if (typeof titleToken === 'function') {
+        titleToken = titleToken(this.currentModel);
       }
 
       if (Ember.isArray(titleToken)) {
@@ -30,14 +30,15 @@ Ember.Route.reopen({
 
       // If `title` exists, it signals the end of the
       // token-collection, and the title is decided right here.
-      if (this.title) {
+      var title = this.get('title');
+      if (title) {
         var finalTitle;
-        if (typeof this.title === 'function') {
-          finalTitle = this.title(tokens);
+        if (typeof title === 'function') {
+          finalTitle = title(tokens);
         } else {
           // Tokens aren't even considered... a string
           // title just sledgehammer overwrites any children tokens.
-          finalTitle = this.title;
+          finalTitle = title;
         }
 
         // Stubbable fn that sets document.title


### PR DESCRIPTION
The upgrade to ember 1.10.0-beta broke accessing `this.title` directly.

It does mean that if you have a computed property, you can't pass the token list.