### PR TITLE
Add the `this` context back to the titleToken call

### DIFF
--- a/vendor/document-title/document-title.js
+++ b/vendor/document-title/document-title.js
@@ -21,7 +21,7 @@ Ember.Route.reopen({
     collectTitleTokens: function(tokens) {
       var titleToken = get(this, 'titleToken');
       if (typeof titleToken === 'function') {
-        titleToken = titleToken(get(this, 'currentModel'));
+        titleToken = titleToken.call(this, get(this, 'currentModel'));
       }
 
       if (Ember.isArray(titleToken)) {


### PR DESCRIPTION
calling `titleToken()` directly sets `this` to `window`. We've been used to `this` being the current route, allowing for some pattern matching in the title against the current path, etc.