### PR TITLE
Fix context for title

### DIFF
--- a/tests/acceptance/document-title-test.js
+++ b/tests/acceptance/document-title-test.js
@@ -51,6 +51,7 @@ test('dynamic title based on route attributes', function(assert) {
   visit('/friendship-status');
 
   andThen(function() {
-    assert.equal(router._title, 'We are friends - My Blog');
+    assert.equal(router._title, 'We are best friends',
+      'the context is correct for `title` and `titleToken`');
   });
 });

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -9,7 +9,7 @@ Router.map(function() {
   this.resource('posts', function() {});
   this.route('about');
   this.route('team');
-  this.route('friendship-status');
+  this.resource('friendship-status', function() {});
 });
 
 export default Router;

--- a/tests/dummy/app/routes/friendship-status.js
+++ b/tests/dummy/app/routes/friendship-status.js
@@ -1,9 +1,9 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
-  status: 'friends',
+  degree: 'best',
 
-  titleToken: function(model) {
-    return 'We are ' + this.get('status');
+  title: function(tokens) {
+    return 'We are ' + this.get('degree') + ' ' + tokens[0];
   }
 });

--- a/tests/dummy/app/routes/friendship-status/index.js
+++ b/tests/dummy/app/routes/friendship-status/index.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  status: 'friends',
+
+  titleToken: function(model) {
+    return this.get('status');
+  }
+});

--- a/vendor/document-title/document-title.js
+++ b/vendor/document-title/document-title.js
@@ -36,7 +36,7 @@ Ember.Route.reopen({
       if (title) {
         var finalTitle;
         if (typeof title === 'function') {
-          finalTitle = title(tokens);
+          finalTitle = title.call(this, tokens);
         } else {
           // Tokens aren't even considered... a string
           // title just sledgehammer overwrites any children tokens.


### PR DESCRIPTION
The context was incorrect for the `title` function as well. Same fix as #5.

Modified the tests to test both `title` and `titleToken`.