### PR TITLE
Guards around document for fastboot

### DIFF
--- a/vendor/document-title/document-title.js
+++ b/vendor/document-title/document-title.js
@@ -62,7 +62,10 @@ Ember.Router.reopen({
     if (Ember.testing) {
       this._title = title;
     } else {
-      window.document.title = title;
+      // In Ember Fastboot, document is not available
+      if (typeof(window.document) !== 'undefined') {
+        window.document.title = title;
+      }
     }
   }
 });


### PR DESCRIPTION
Document is not defined in fastboot, so we have to guard around it