### PR TITLE
Allow usage with ember-cli-fastboot.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,13 @@ cache:
   directories:
     - node_modules
 
+env:
+  - EMBER_TRY_SCENARIO=ember-1.10
+  - EMBER_TRY_SCENARIO=ember-1.11
+  - EMBER_TRY_SCENARIO=ember-release
+  - EMBER_TRY_SCENARIO=ember-beta
+  - EMBER_TRY_SCENARIO=ember-canary
+
 before_install:
   - "npm config set spin false"
   - "npm install -g npm@^2"
@@ -17,4 +24,4 @@ install:
   - bower install
 
 script:
-  - npm test
+  - ember try $EMBER_TRY_SCENARIO test

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,0 +1,43 @@
+module.exports = {
+  scenarios: [
+    {
+      name: 'ember-1.10',
+      dependencies: {
+        "ember": "~1.10.0"
+      }
+    },
+    {
+      name: 'ember-1.11',
+      dependencies: {
+        "ember": "~1.11.0"
+      }
+    },
+    {
+      name: 'ember-release',
+      dependencies: {
+        "ember": "release"
+      },
+      resolutions: {
+        "ember": "release"
+      }
+    },
+    {
+      name: 'ember-beta',
+      dependencies: {
+        "ember": "beta"
+      },
+      resolutions: {
+        "ember": "beta"
+      }
+    },
+    {
+      name: 'ember-canary',
+      dependencies: {
+        "ember": "canary"
+      },
+      resolutions: {
+        "ember": "canary"
+      }
+    }
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   "devDependencies": {
     "broccoli-asset-rev": "^2.0.0",
     "ember-cli": "0.2.0-beta.1",
-    "ember-cli-babel": "^4.0.0",
     "ember-cli-app-version": "0.3.1",
+    "ember-cli-babel": "^4.0.0",
     "ember-cli-content-security-policy": "0.3.0",
     "ember-cli-dependency-checker": "0.0.7",
     "ember-cli-htmlbars": "0.7.4",
@@ -38,6 +38,7 @@
     "ember-cli-uglify": "1.0.1",
     "ember-data": "1.0.0-beta.15",
     "ember-export-application-global": "^1.0.2",
+    "ember-try": "0.0.5",
     "express": "^4.8.5",
     "glob": "^4.0.5"
   },

--- a/tests/acceptance/document-title-test.js
+++ b/tests/acceptance/document-title-test.js
@@ -21,7 +21,7 @@ test('Show default title properly - no tokens', function(assert) {
   visit('/');
 
   andThen(function() {
-    assert.equal(router._title, 'My Blog', 'Default title is correct');
+    assert.equal(document.title, 'My Blog', 'Default title is correct');
   });
 });
 
@@ -31,7 +31,7 @@ test('static title doesn\'t bubble', function(assert) {
   visit('/about');
 
   andThen(function() {
-    assert.equal(router._title, 'About Us', 'It doesn\'t bubble up');
+    assert.equal(document.title, 'About Us', 'It doesn\'t bubble up');
   });
 });
 
@@ -41,7 +41,7 @@ test('bubbling title tokens', function(assert) {
   visit('/team');
 
   andThen(function() {
-    assert.equal(router._title, 'The Team - My Blog', 'The title token bubbles up');
+    assert.equal(document.title, 'The Team - My Blog', 'The title token bubbles up');
   });
 });
 
@@ -51,7 +51,7 @@ test('dynamic title based on a model', function(assert) {
   visit('/posts');
 
   andThen(function() {
-    assert.equal(router._title, 'Ember is omakase - Posts - My Blog');
+    assert.equal(document.title, 'Ember is omakase - Posts - My Blog');
   });
 });
 
@@ -61,7 +61,7 @@ test('dynamic title based on route attributes', function(assert) {
   visit('/friendship-status');
 
   andThen(function() {
-    assert.equal(router._title, 'We are best friends',
+    assert.equal(document.title, 'We are best friends',
       'the context is correct for `title` and `titleToken`');
   });
 });

--- a/tests/acceptance/document-title-test.js
+++ b/tests/acceptance/document-title-test.js
@@ -2,16 +2,17 @@ import Ember from 'ember';
 import { module, test } from 'qunit';
 import startApp from '../helpers/start-app';
 
-var application, router;
+var application, originalTitle;
 
 module('Acceptance: DocumentTitle', {
   beforeEach: function() {
+    originalTitle = document.title;
     application = startApp();
-    router = application.__container__.lookup('router:main');
   },
 
   afterEach: function() {
     Ember.run(application, 'destroy');
+    document.title = originalTitle;
   }
 });
 

--- a/tests/unit/router-test.js
+++ b/tests/unit/router-test.js
@@ -1,0 +1,41 @@
+import Ember from 'ember';
+import { module, test } from 'qunit';
+
+var container, registry, router, originalTitle;
+
+module('router:main', {
+  beforeEach: function() {
+    originalTitle = document.title;
+    container = new Ember.Container();
+    registry = container._registry || container;
+
+    registry.register('location:none', Ember.NoneLocation);
+
+    router = Ember.Router.create({
+      location: 'none',
+      container: container
+    });
+  },
+
+  afterEach: function() {
+    document.title = originalTitle;
+  }
+});
+
+test('it sets document title on the renderer:-dom if present', function(assert) {
+  var renderer = { _dom: { document: {} } };
+
+  registry.register('renderer:-dom', {
+    create: function() {
+      return renderer;
+    }
+  });
+
+  router.setTitle('foo - renderer test');
+  assert.equal(renderer._dom.document.title, 'foo - renderer test', 'title should be set on the renderer');
+});
+
+test('it sets document title on the real `document.title` if renderer is not present', function(assert) {
+  router.setTitle('foo - no renderer test');
+  assert.equal(document.title, 'foo - no renderer test', 'title should be set on the document');
+});

--- a/vendor/document-title/document-title.js
+++ b/vendor/document-title/document-title.js
@@ -59,10 +59,12 @@ Ember.Router.reopen({
   }),
 
   setTitle: function(title) {
-    if (Ember.testing) {
-      this._title = title;
+    var renderer = this.container.lookup('renderer:-dom');
+
+    if (renderer) {
+      Ember.set(renderer, '_dom.document.title', title);
     } else {
-      window.document.title = title;
+      document.title = title;
     }
   }
 });


### PR DESCRIPTION
* `renderer:-dom` is provided in versions of Ember > 1.10.
* Actually test the real document.title in `ember test` (to help ensure this is really working).