### PR TITLE
use actions instead of removed _actions in ember 2.0.0

### DIFF
--- a/vendor/document-title/document-title.js
+++ b/vendor/document-title/document-title.js
@@ -17,7 +17,7 @@ Ember.Route.reopen({
   title: null,
 
   // Provided by Ember
-  _actions: {
+  actions: {
     collectTitleTokens: function(tokens) {
       var titleToken = get(this, 'titleToken');
       if (typeof titleToken === 'function') {


### PR DESCRIPTION
This resolves issue #23. Currently ember-cli-document-title breaks Ember 2.0.0.