### PR TITLE
Fix tests using `container._registry`.

### DIFF
--- a/tests/unit/router-test.js
+++ b/tests/unit/router-test.js
@@ -6,8 +6,13 @@ var container, registry, router, originalTitle;
 module('router:main', {
   beforeEach: function() {
     originalTitle = document.title;
-    container = new Ember.Container();
-    registry = container._registry || container;
+    
+    if (Ember.Registry) {
+      registry = new Ember.Registry();
+      container = registry.container();
+    } else {
+      registry = container = new Ember.Container();
+    }
 
     registry.register('location:none', Ember.NoneLocation);
 


### PR DESCRIPTION
`container._registry` has been removed in 2.0.0.