### PR TITLE
Support ember-2.3.0+

### DIFF
--- a/tests/unit/router-test.js
+++ b/tests/unit/router-test.js
@@ -20,6 +20,10 @@ module('router:main', {
       location: 'none',
       container: container
     });
+
+    if (Ember.setOwner) {
+      Ember.setOwner(router, container);
+    }
   },
 
   afterEach: function() {

--- a/vendor/document-title/document-title.js
+++ b/vendor/document-title/document-title.js
@@ -1,4 +1,5 @@
 var get = Ember.get;
+var getOwner = Ember.getOwner;
 
 var routeProps = {
   // `titleToken` can either be a static string or a function
@@ -77,7 +78,8 @@ Ember.Router.reopen({
   }),
 
   setTitle: function(title) {
-    var renderer = this.container.lookup('renderer:-dom');
+    var container = getOwner ? getOwner(this) : this.container;
+    var renderer = container.lookup('renderer:-dom');
 
     if (renderer) {
       Ember.set(renderer, '_dom.document.title', title);


### PR DESCRIPTION
`this.container.lookup` is now deprecated API in ember 2.3.0