### PR TITLE
Fix example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ And continue to the Application Route:
 export default Ember.Route.extend({
   title: function(tokens) {
    tokens = Ember.makeArray(tokens);
-   tokens.push('My Blog');
+   tokens.unshift('My Blog');
    return tokens.reverse().join(' - ');
   }
 });


### PR DESCRIPTION
Example in README shows how to use the addon with nested routes.

**Actual**:  If we follow the steps of the example  we get "My Blog - Ember is Omakase - Posts"
**Expected**: "Ember is Omakase - Posts - My Blog"

**Solution**
Token array is filled internally with `unshift`, so in order to add the top level token for the whole app in the application route it should be done with `unshift` instead of `push`.