### PR TITLE
Updated fastboot compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ Install by running
 ember install ember-cli-document-title
 ```
 
+### Remove existing <title> tag
+As of version `0.4.0` this addon sets the document title by adding a
+`<title>` tag within your document's `<head>`.  As such to avoid a
+duplicated title you will need to remove the current existing
+`<title>` tag from `app/index.html`.
+
 ## So, how does this work?
 This adds two new keys to your routes:
 

--- a/app/templates/head.hbs
+++ b/app/templates/head.hbs
@@ -1,0 +1,5 @@
+<!-- `app/templates/head.hbs` -->
+<!-- content from ember-cli-document-title, injected by ember-cli-head -->
+<!-- The 'model' available in this template can be populated by -->
+<!-- setting values on the 'head-data' service. -->
+<title>{{model.title}}</title>

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "ember-addon"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.5"
+    "ember-cli-babel": "^5.1.5",
+    "ember-cli-head": "0.0.5"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-document-title",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Adding document title functionality to your ember app",
   "main": "index.js",
   "directories": {

--- a/tests/acceptance/document-title-test.js
+++ b/tests/acceptance/document-title-test.js
@@ -2,17 +2,15 @@ import Ember from 'ember';
 import { module, test } from 'qunit';
 import startApp from '../helpers/start-app';
 
-var application, originalTitle;
+let application;
 
 module('Acceptance: DocumentTitle', {
   beforeEach: function() {
-    originalTitle = document.title;
     application = startApp();
   },
 
   afterEach: function() {
     Ember.run(application, 'destroy');
-    document.title = originalTitle;
   }
 });
 
@@ -22,7 +20,7 @@ test('Show default title properly - no tokens', function(assert) {
   visit('/');
 
   andThen(function() {
-    assert.equal(document.title, 'My Blog', 'Default title is correct');
+    assert.equal(find('title', 'head').text(), 'My Blog', 'Default title is correct');
   });
 });
 
@@ -32,7 +30,7 @@ test('static title doesn\'t bubble', function(assert) {
   visit('/about');
 
   andThen(function() {
-    assert.equal(document.title, 'About Us', 'It doesn\'t bubble up');
+    assert.equal(find('title', 'head').text(), 'About Us', 'It doesn\'t bubble up');
   });
 });
 
@@ -42,7 +40,7 @@ test('bubbling title tokens', function(assert) {
   visit('/team');
 
   andThen(function() {
-    assert.equal(document.title, 'The Team - My Blog', 'The title token bubbles up');
+    assert.equal(find('title', 'head').text(), 'The Team - My Blog', 'The title token bubbles up');
   });
 });
 
@@ -52,7 +50,7 @@ test('dynamic title based on a model', function(assert) {
   visit('/posts');
 
   andThen(function() {
-    assert.equal(document.title, 'Ember is omakase - Posts - My Blog');
+    assert.equal(find('title', 'head').text(), 'Ember is omakase - Posts - My Blog');
   });
 });
 
@@ -62,7 +60,7 @@ test('dynamic title based on route attributes', function(assert) {
   visit('/friendship-status');
 
   andThen(function() {
-    assert.equal(document.title, 'We are best friends',
+    assert.equal(find('title', 'head').text(), 'We are best friends',
       'the context is correct for `title` and `titleToken`');
   });
 });
@@ -73,7 +71,7 @@ test('returning an array from titleToken works', function(assert) {
   visit('/candy');
 
   andThen(function() {
-    assert.equal(document.title,
+    assert.equal(find('title', 'head').text(),
       'My favorite candies are dumle and sort pepper');
   });
 });
@@ -84,12 +82,12 @@ test('title updates when you switch routes', function(assert) {
   visit('/about');
 
   andThen(function() {
-    assert.equal(document.title, 'About Us');
+    assert.equal(find('title', 'head').text(), 'About Us');
   });
 
   click('.test-posts-link');
 
   andThen(function() {
-    assert.equal(document.title, 'Ember is omakase - Posts - My Blog');
+    assert.equal(find('title', 'head').text(), 'Ember is omakase - Posts - My Blog');
   });
 });

--- a/tests/dummy/app/index.html
+++ b/tests/dummy/app/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>Sane Document Title</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 

--- a/tests/index.html
+++ b/tests/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>Dummy Tests</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 

--- a/tests/unit/router-test.js
+++ b/tests/unit/router-test.js
@@ -1,12 +1,12 @@
 import Ember from 'ember';
-import { module, test } from 'qunit';
+import { module, skip } from 'qunit';
 
 var container, registry, router, originalTitle;
 
 module('router:main', {
   beforeEach: function() {
     originalTitle = document.title;
-    
+
     if (Ember.Registry) {
       registry = new Ember.Registry();
       container = registry.container();
@@ -31,7 +31,7 @@ module('router:main', {
   }
 });
 
-test('it sets document title on the renderer:-dom if present', function(assert) {
+skip('it sets document title on the renderer:-dom if present', function(assert) {
   var renderer = { _dom: { document: {} } };
 
   registry.register('renderer:-dom', {
@@ -44,7 +44,7 @@ test('it sets document title on the renderer:-dom if present', function(assert) 
   assert.equal(renderer._dom.document.title, 'foo - renderer test', 'title should be set on the renderer');
 });
 
-test('it sets document title on the real `document.title` if renderer is not present', function(assert) {
+skip('it sets document title on the real `document.title` if renderer is not present', function(assert) {
   router.setTitle('foo - no renderer test');
   assert.equal(document.title, 'foo - no renderer test', 'title should be set on the document');
 });

--- a/tests/unit/router-test.js
+++ b/tests/unit/router-test.js
@@ -1,11 +1,10 @@
 import Ember from 'ember';
-import { module, skip } from 'qunit';
+import { module, test } from 'qunit';
 
-var container, registry, router, originalTitle;
+let container, registry, router;
 
 module('router:main', {
   beforeEach: function() {
-    originalTitle = document.title;
 
     if (Ember.Registry) {
       registry = new Ember.Registry();
@@ -26,25 +25,15 @@ module('router:main', {
     }
   },
 
-  afterEach: function() {
-    document.title = originalTitle;
-  }
 });
 
-skip('it sets document title on the renderer:-dom if present', function(assert) {
-  var renderer = { _dom: { document: {} } };
-
-  registry.register('renderer:-dom', {
+test('it sets document title on the headData service', function(assert) {
+  let headData = {};
+  registry.register('service:headData', {
     create: function() {
-      return renderer;
+      return headData;
     }
   });
-
-  router.setTitle('foo - renderer test');
-  assert.equal(renderer._dom.document.title, 'foo - renderer test', 'title should be set on the renderer');
-});
-
-skip('it sets document title on the real `document.title` if renderer is not present', function(assert) {
-  router.setTitle('foo - no renderer test');
-  assert.equal(document.title, 'foo - no renderer test', 'title should be set on the document');
+  router.setTitle('foo - head-data test');
+  assert.equal(headData.title, 'foo - head-data test', 'title should be set on the head-data service');
 });

--- a/vendor/document-title/document-title.js
+++ b/vendor/document-title/document-title.js
@@ -1,5 +1,4 @@
 var get = Ember.get;
-var getOwner = Ember.getOwner;
 
 var routeProps = {
   // `titleToken` can either be a static string or a function
@@ -73,18 +72,13 @@ routeProps[mergedActionPropertyName] = {
 Ember.Route.reopen(routeProps);
 
 Ember.Router.reopen({
+  headData: Ember.inject.service(),
+
   updateTitle: Ember.on('didTransition', function() {
     this.send('collectTitleTokens', []);
   }),
 
   setTitle: function(title) {
-    var container = getOwner ? getOwner(this) : this.container;
-    var renderer = container.lookup('renderer:-dom');
-
-    if (renderer) {
-      Ember.set(renderer, '_dom.document.title', title);
-    } else {
-      document.title = title;
-    }
+    this.set('headData.title', title);
   }
 });


### PR DESCRIPTION
FastBoot is moving to a solution where the entire contents of `<head>` and `<body>` are injected into the document.  In the near future [title substitution](https://github.com/ember-fastboot/ember-fastboot-server/blob/master/lib/server.js#L61-L63) will be removed entirely in favor of head substitution.  This update switches the dependency on title substitution to use [ember-cli-head](https://github.com/ronco/ember-cli-head) for setting the title.

Following semver I've bumped the version since this change will require users to remove the existing `<title>` tag from their index.html.  Suggestions for changes welcome.

/cc @tomdale @rwjblue 