### PR TITLE
Added support for Glimmer 2. Fixes #46.

### DIFF
--- a/vendor/document-title/document-title.js
+++ b/vendor/document-title/document-title.js
@@ -81,8 +81,12 @@ Ember.Router.reopen({
     var container = getOwner ? getOwner(this) : this.container;
     var renderer = container.lookup('renderer:-dom');
 
-    if (renderer) {
+    if (renderer && renderer._dom) {
       Ember.set(renderer, '_dom.document.title', title);
+    } else if (renderer && renderer._env && renderer._env.getDOM) {
+      // Glimmer 2 has a different renderer
+      var dom = renderer._env.getDOM();
+      Ember.set(dom, 'document.title', title);
     } else {
       document.title = title;
     }


### PR DESCRIPTION
This also improves the logic for the `document.title = title` fallback.

Fixes #46 