### PR TITLE
Fix setting title in fastboot with glimmer2

### DIFF
--- a/vendor/document-title/document-title.js
+++ b/vendor/document-title/document-title.js
@@ -80,13 +80,13 @@ Ember.Router.reopen({
   setTitle: function(title) {
     var container = getOwner ? getOwner(this) : this.container;
     var renderer = container.lookup('renderer:-dom');
+    var domForAppWithGlimmer2 = container.lookup('service:-document');
 
     if (renderer && renderer._dom) {
       Ember.set(renderer, '_dom.document.title', title);
-    } else if (renderer && renderer._env && renderer._env.getDOM) {
+    } else if (domForAppWithGlimmer2) {
       // Glimmer 2 has a different renderer
-      var dom = renderer._env.getDOM();
-      Ember.set(dom, 'document.title', title);
+      Ember.set(domForAppWithGlimmer2, 'title', title);
     } else {
       document.title = title;
     }


### PR DESCRIPTION
#49  tried to fix glimmer 2 but it wasn't correct.

Calling `renderer._env.getDOM()` in fastboot environments gives back `undefined`. Ember now allows you to get the DOM object (whether SimpleDOM in fastboot environment or DOM in browser). 

This PR fixes setting title propertly in fastboot environment for apps using 2.9.beta.x. The earlier check was incorrect.

PS: I am keeping the `else if (domForAppWithGlimmer2)` since not all apps may be on 2.9.beta.x that will contain the document service. 

cc: @chadhietala @kimroen @workmanw 

Tested this with fastboot app.
