### PR TITLE
Set up testing for FastBoot

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,7 @@
 /bower_components
 /config/ember-try.js
 /dist
+/fastboot-tests
 /tests
 /tmp
 **/.gitkeep

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ env:
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary
+  - EMBER_TRY_SCENARIO=fastboot-addon-tests
   - EMBER_TRY_SCENARIO=ember-default
 
 matrix:

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -90,6 +90,13 @@ module.exports = {
       }
     },
     {
+      name: 'fastboot-addon-tests',
+      command: 'ember fastboot:test',
+      npm: {
+        devDependencies: {}
+      }
+    },
+    {
       name: 'ember-default',
       npm: {
         devDependencies: {}

--- a/fastboot-tests/fixtures/fastboot/app/index.html
+++ b/fastboot-tests/fixtures/fastboot/app/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Sane Document Title</title>
+    <meta name="description" content="">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    {{content-for "head"}}
+
+    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/dummy.css">
+
+    {{content-for "head-footer"}}
+  </head>
+  <body>
+    {{content-for "body"}}
+
+    <script src="{{rootURL}}/assets/vendor.js"></script>
+    <script src="{{rootURL}}/assets/dummy.js"></script>
+
+    {{content-for "body-footer"}}
+  </body>
+</html>

--- a/fastboot-tests/fixtures/fastboot/app/router.js
+++ b/fastboot-tests/fixtures/fastboot/app/router.js
@@ -1,0 +1,12 @@
+import Ember from 'ember';
+import config from './config/environment';
+
+const Router = Ember.Router.extend({
+  location: config.locationType,
+  rootURL: config.rootURL
+});
+
+Router.map(function() {
+});
+
+export default Router;

--- a/fastboot-tests/fixtures/fastboot/app/routes/application.js
+++ b/fastboot-tests/fixtures/fastboot/app/routes/application.js
@@ -1,0 +1,8 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  title(tokens) {
+    tokens = [...tokens, "application"];
+    return tokens.reverse().join(' - ');
+  }
+});

--- a/fastboot-tests/fixtures/fastboot/app/routes/index.js
+++ b/fastboot-tests/fixtures/fastboot/app/routes/index.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  titleToken() {
+    return "index";
+  }
+});

--- a/fastboot-tests/fixtures/fastboot/app/templates/index.hbs
+++ b/fastboot-tests/fixtures/fastboot/app/templates/index.hbs
@@ -1,0 +1,1 @@
+<h1>ember-fastboot-addon-tests</h1>

--- a/fastboot-tests/index-test.js
+++ b/fastboot-tests/index-test.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const expect = require('chai').expect;
+const setupTest = require('ember-fastboot-addon-tests').setupTest;
+
+describe('index', function() {
+  setupTest('fastboot'/*, options */);
+
+  it('renders', function() {
+    return this.visit('/')
+      .then(function(res) {
+        let $ = res.jQuery;
+        let response = res.response;
+
+        // add your real tests here
+        expect(response.statusCode).to.equal(200);
+        expect($('body').length).to.equal(1);
+        expect($('h1').text().trim()).to.equal('ember-fastboot-addon-tests');
+      });
+  });
+
+});

--- a/fastboot-tests/index-test.js
+++ b/fastboot-tests/index-test.js
@@ -16,6 +16,7 @@ describe('index', function() {
         expect(response.statusCode).to.equal(200);
         expect($('body').length).to.equal(1);
         expect($('h1').text().trim()).to.equal('ember-fastboot-addon-tests');
+        expect($('title').text().trim()).to.equal('Sane Document Title');
       });
   });
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
+    "chai": "^4.1.2",
     "ember-cli": "~2.14.2",
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-eslint": "^3.0.0",
@@ -42,6 +43,7 @@
     "ember-cli-uglify": "^1.2.0",
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.0",
+    "ember-fastboot-addon-tests": "^0.4.0",
     "ember-load-initializers": "^1.0.0",
     "ember-resolver": "^4.0.0",
     "ember-source": "~2.14.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "ember build",
     "start": "ember server",
-    "test": "ember try:each"
+    "test": "ember try:each && ember fastboot:test"
   },
   "dependencies": {
     "ember-cli-babel": "^6.3.0"


### PR DESCRIPTION
This prepares for writing tests for FastBoot using the `ember-fastboot-addon-tests` package.

There's a test in here, but it merely confirms that the title doesn't change at all when using FastBoot without any further work. We could add some tests for the case when `ember-cli-head` is installed, but I'd rather integrate with it instead, I think.

Fixes #52 