### PR TITLE
Set up Fastboot tests to use ember-cli-head

### DIFF
--- a/fastboot-tests/.eslintrc.js
+++ b/fastboot-tests/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  env: {
+    node: true,
+    mocha: true
+  }
+};

--- a/fastboot-tests/fixtures/fastboot/app/index.html
+++ b/fastboot-tests/fixtures/fastboot/app/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>Sane Document Title</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 

--- a/fastboot-tests/fixtures/fastboot/app/router.js
+++ b/fastboot-tests/fixtures/fastboot/app/router.js
@@ -3,7 +3,13 @@ import config from './config/environment';
 
 const Router = Ember.Router.extend({
   location: config.locationType,
-  rootURL: config.rootURL
+  rootURL: config.rootURL,
+
+  headData: Ember.inject.service(),
+
+  setTitle(title) {
+    this.get('headData').set('title', title);
+  }
 });
 
 Router.map(function() {

--- a/fastboot-tests/fixtures/fastboot/app/templates/head.hbs
+++ b/fastboot-tests/fixtures/fastboot/app/templates/head.hbs
@@ -1,0 +1,6 @@
+{{!--
+  Add content you wish automatically added to the documents head
+  here. The 'model' available in this template can be populated by
+  setting values on the 'head-data' service.
+--}}
+<title>{{model.title}}</title>

--- a/fastboot-tests/index-test.js
+++ b/fastboot-tests/index-test.js
@@ -4,7 +4,11 @@ const expect = require('chai').expect;
 const setupTest = require('ember-fastboot-addon-tests').setupTest;
 
 describe('index', function() {
-  setupTest('fastboot'/*, options */);
+  setupTest('fastboot', {
+    installPackages: {
+      "ember-cli-head": "^0.3.1"
+    }
+  });
 
   it('renders', function() {
     return this.visit('/')
@@ -12,11 +16,10 @@ describe('index', function() {
         let $ = res.jQuery;
         let response = res.response;
 
-        // add your real tests here
         expect(response.statusCode).to.equal(200);
         expect($('body').length).to.equal(1);
         expect($('h1').text().trim()).to.equal('ember-fastboot-addon-tests');
-        expect($('title').text().trim()).to.equal('Sane Document Title');
+        expect($('title').text().trim()).to.equal('application - index');
       });
   });
 


### PR DESCRIPTION
Following up on #58 and in preparation for adding tests to #60, this alters the setup to use the `ember-cli-head` addon for testing the title being rendered in FastBoot.