### PR TITLE
Add TypeScript ambient type information

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,16 @@
+declare module 'ember' {
+  /**
+   * NOTE: because of the way @types/ember works,
+   * merging a few properties into the Ember.Route interface
+   * will also result in the @ember/routing/route default export
+   * having these properties too.
+   * -- @mike-north
+   */
+  namespace Ember {
+    interface Route {
+      titleToken: string;
+      title: string;
+      setTitle: (title: string) => void;
+    }
+  }
+}


### PR DESCRIPTION
Fixes #65 

Because this is an 'extension of ember' kind of addon (often used without being explicitly imported), consumers will need to do **one of two things** in order to take advantage of this type information.

### A. Indicate that this type information is to be included
##### tsconfig.json
```json
{
  "compilerOptions": {
      "types": [
         "ember-cli-document-title"
       ]
  }
}
``` 

### B. Import the entry point for this addon from somewhere in their project

##### app/app.ts
```ts
import Application from '@ember/application';
import loadInitializers from 'ember-load-initializers';
import config from './config/environment';
import Resolver from './resolver';
// ⬇️ ⬇️ ⬇️ ⬇️ ⬇️ ⬇️ ⬇️ ⬇️ ⬇️ ⬇️ ⬇️ ⬇️ 
import 'ember-cli-document-title';

const App = Application.extend({ ... });
```