### PR TITLE
Evaluate isFastboot computed property

### DIFF
--- a/vendor/document-title/document-title.js
+++ b/vendor/document-title/document-title.js
@@ -77,7 +77,7 @@ routeProps[mergedActionPropertyName] = {
 
       // Tell FastBoot about our async code
       var fastboot = lookupFastBoot(this);
-      if (fastboot && fastboot.isFastBoot) {
+      if (fastboot && fastboot.get('isFastBoot')) {
         fastboot.deferRendering(completion);
       }
 


### PR DESCRIPTION
For apps that have the Fastboot service but aren't using it yet, [this line](https://github.com/kimroen/ember-cli-document-title/blob/master/vendor/document-title/document-title.js#L80) causes a show-stopping error. This is because the computed property `isFastboot` wasn't being evaluated.

Ran the addon and Fastboot tests, they all pass.