### PR TITLE
Use newer private `_router` when available. Fixes #71.

### DIFF
--- a/vendor/document-title/document-title.js
+++ b/vendor/document-title/document-title.js
@@ -71,8 +71,10 @@ routeProps[mergedActionPropertyName] = {
         }
       })
       .then(function(finalTitle) {
+        var router = self._router || self.router;
+
         // Stubbable fn that sets document.title
-        self.router.setTitle(finalTitle);
+        router.setTitle(finalTitle);
       });
 
       // Tell FastBoot about our async code


### PR DESCRIPTION
Fixes deprecations on `Ember 3.1+`