### PR TITLE
Rename Promise to a different name

### DIFF
--- a/vendor/document-title/document-title.js
+++ b/vendor/document-title/document-title.js
@@ -1,6 +1,6 @@
 var get = Ember.get;
 var getOwner = Ember.getOwner;
-var Promise = Ember.RSVP.Promise;
+var RSVPromise = Ember.RSVP.Promise;
 
 var routeProps = {
   // `titleToken` can either be a static string or a function
@@ -56,11 +56,11 @@ routeProps[mergedActionPropertyName] = {
       var self = this;
 
       // Wrap in promise in case some tokens are asynchronous.
-      var completion = Promise.resolve()
+      var completion = RSVPromise.resolve()
       .then(function() {
         if (typeof title === 'function') {
           // Wait for all tokens to resolve. It resolves immediately if all tokens are plain values (not promises).
-          return Promise.all(tokens)
+          return RSVPromise.all(tokens)
             .then(function(resolvedTokens) {
               return title.call(self, resolvedTokens);
             });


### PR DESCRIPTION
This was a weird one 😄 

I bumped to 0.4.0 from 0.3.3 and noticed some of my tests were failing even though they had nothing to do with ember-cli-document-title. Turns out that `var Promise` was clobbering `window.Promise` which caused issues. Because the addon code is in a vendor file it just gets inlined as is into the vendor.js which means any variables defined here are global. Here I've renamed `Promise` to `RSVPromise` to prevent any clobbering.